### PR TITLE
Modernize site: multi-page layout, Substack feed, and portrait placeholder

### DIFF
--- a/StyleSheets.css
+++ b/StyleSheets.css
@@ -1,130 +1,201 @@
 :root {
-    --primary-color: teal;
-    --accent-color: peachpuff;
-    --background-color: #222;
+    --bg: #0f172a;
+    --surface: #111827;
+    --surface-2: #1f2937;
+    --text: #e5e7eb;
+    --muted: #9ca3af;
+    --brand: #2dd4bf;
+    --brand-2: #14b8a6;
+    --max-width: 1080px;
+}
+
+* {
+    box-sizing: border-box;
 }
 
 body {
-    background-color: var(--background-color);
-    color: var(--accent-color);
+    margin: 0;
     font-family: 'Open Sans', sans-serif;
-    font-size: 1rem;
-    text-align: center;
+    background: linear-gradient(180deg, #0b1120 0%, var(--bg) 100%);
+    color: var(--text);
+    line-height: 1.6;
 }
 
-.project-img {
-    width: 20vw;
-    height: auto;
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-}
-
-.project-list {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
-.project-list a {
-    margin: 0.5rem 0;
-    display: block;
-}
-
-.art-img {
-    width: 30vw;
-    height: auto;
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-    margin: 0.5rem;
-}
-
-.icon {
-    width: 2rem;
-    height: 2rem;
-    display: inline-block;
-}
-
-ul {
-    text-align: left;
-    display: inline-block;
-    list-style-position: inside;
-    list-style: none;
-    padding: 0;
-}
-
-nav li {
-    display: inline-block;
-}
-
-hr{
-    display: block;
-    height: 2px;
-    background-color: var(--primary-color);
-}
-
-header {
-    z-index: 2;
-    background: var(--primary-color);
-    color: var(--accent-color);
-    opacity: 0.95;
-    position: fixed;
-    right: 0;
-    left: 0;
-    top: 0;
-    padding: 1rem 0;
-    transition: padding 0.3s, background 0.3s;
-}
-
-header.shrink {
-    padding: 0.5rem 0;
-    background: rgba(0,128,128,0.9);
-}
-
-h1 {
-    font-size: 2rem;
-    color: var(--accent-color);
-}
-
-div.a {
-    z-index: 1;
-    position: relative;
-    margin-top: 12rem;
-}
-
-.whitetext {
-    color: var(--accent-color);
-    font-size: 1rem;
-}
-
-a{
+a {
+    color: inherit;
     text-decoration: none;
 }
 
-#cvlocation {
-    scroll-margin-top: 12rem;
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    backdrop-filter: blur(10px);
+    background: rgba(15, 23, 42, 0.88);
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
 }
 
-#contact{
-    scroll-margin-top: 12rem;
+.nav-wrap {
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
 }
 
-.section-spacing {
-    margin-top: 5rem;
+.site-title {
+    font-size: 1.25rem;
+    margin: 0;
 }
 
-nav a:hover {
-    opacity: 0.7;
+.nav-links {
+    list-style: none;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 0;
 }
 
-nav a.active {
-    border-bottom: 2px solid var(--accent-color);
+.nav-links a {
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    color: var(--muted);
 }
 
-#sim {
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+.nav-links a:hover,
+.nav-links a.active {
+    color: var(--text);
+    background: rgba(45, 212, 191, 0.16);
 }
 
-#cv {
-    background-color: white;
+.page {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 2rem 1rem 3rem;
+}
+
+.hero,
+.card {
+    background: rgba(17, 24, 39, 0.9);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    border-radius: 16px;
+    padding: 1.5rem;
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: 170px 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.portrait-placeholder {
+    width: 100%;
+    aspect-ratio: 1;
+    border-radius: 14px;
+    border: 2px dashed rgba(148, 163, 184, 0.4);
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    font-size: 0.95rem;
+    text-align: center;
+    padding: 0.75rem;
+    background: rgba(31, 41, 55, 0.45);
+}
+
+.grid {
+    margin-top: 1.25rem;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+h1,
+h2,
+h3 {
+    line-height: 1.2;
+    margin-top: 0;
+}
+
+.muted {
+    color: var(--muted);
+}
+
+.article-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: grid;
+    gap: 0.9rem;
+}
+
+.article-list li {
+    background: rgba(31, 41, 55, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.15);
+    border-radius: 12px;
+    padding: 0.9rem;
+}
+
+.article-list h3 {
+    margin: 0 0 0.2rem;
+    font-size: 1rem;
+}
+
+.article-list time {
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.art-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.art-img {
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.contact-links {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+}
+
+.contact-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.5rem 0.8rem;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 999px;
+    color: var(--muted);
+}
+
+.contact-links a:hover {
+    color: var(--text);
+    border-color: var(--brand);
+}
+
+.icon {
+    width: 1rem;
+    height: 1rem;
+}
+
+@media (max-width: 700px) {
+    .hero {
+        grid-template-columns: 1fr;
+    }
+
+    .nav-wrap {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }

--- a/art.html
+++ b/art.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Alexander Mitchiner | Art</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="StyleSheets.css" />
+</head>
+<body>
+<header class="site-header">
+    <div class="nav-wrap">
+        <h1 class="site-title">Alexander Mitchiner</h1>
+        <nav>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a class="active" href="art.html">Art</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+</header>
+
+<main class="page">
+    <section class="card">
+        <h2>Artwork</h2>
+        <p class="muted">A small gallery of your digital pieces.</p>
+        <div class="art-grid">
+            <img class="art-img" src="images/tentacleman.png" alt="A man with tentacles for hair" />
+            <img class="art-img" src="images/tearsinrainwithman.png" alt="A man standing in a courtyard with the night sky above him" />
+            <img class="art-img" src="images/me_but_cute_and_young.png" alt="A digital painting of a younger self" />
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/articles.html
+++ b/articles.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Alexander Mitchiner | Articles</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="StyleSheets.css" />
+</head>
+<body>
+<header class="site-header">
+    <div class="nav-wrap">
+        <h1 class="site-title">Alexander Mitchiner</h1>
+        <nav>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a class="active" href="articles.html">Articles</a></li>
+                <li><a href="art.html">Art</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+</header>
+
+<main class="page">
+    <section class="card">
+        <h2>Recent Substack Articles</h2>
+        <p class="muted" id="article-status">Loading latest posts…</p>
+        <ul id="article-list" class="article-list"></ul>
+    </section>
+</main>
+
+<script src="substack.js"></script>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Alexander Mitchiner | Contact</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="StyleSheets.css" />
+</head>
+<body>
+<header class="site-header">
+    <div class="nav-wrap">
+        <h1 class="site-title">Alexander Mitchiner</h1>
+        <nav>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a href="art.html">Art</a></li>
+                <li><a class="active" href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+</header>
+
+<main class="page">
+    <section class="card">
+        <h2>Contact</h2>
+        <p class="muted">Find me on the following platforms:</p>
+        <ul class="contact-links">
+            <li><a href="https://www.youtube.com/channel/UCqmTxpB8kqBPMWqyi9L9KOg"><img class="icon" src="images/youtubelogo.png" alt="YouTube" />YouTube</a></li>
+            <li><a href="https://github.com/GAMINpanda"><img class="icon" src="images/girhublogo.png" alt="GitHub" />GitHub</a></li>
+            <li><a href="https://www.instagram.com/gamin_panda/"><img class="icon" src="images/instalogo.png" alt="Instagram" />Instagram</a></li>
+            <li><a href="https://www.linkedin.com/in/alexander-mitchiner/"><img class="icon" src="images/linkedinlogo.png" alt="LinkedIn" />LinkedIn</a></li>
+            <li><a href="https://substack.com/@alexandermitchiner"><img class="icon" src="images/substackfill.png" alt="Substack" />Substack</a></li>
+        </ul>
+    </section>
+</main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,100 +1,60 @@
 <!DOCTYPE html>
-        <html>
-                <head>
-                        <meta name="viewport" content="width=device-width, initial-scale=1">
-                        <link rel="preconnect" href="https://fonts.googleapis.com">
-                        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-                        <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet">
-                        <link rel="stylesheet" href="StyleSheets.css" />
-                </head>
-		<body>
-                        <header>
-                                <h1> Alexander Mitchiner</h1>
-				<nav>
-					<ul>
-						<li><a href="index.html" class="whitetext">Home</a></li>
-						<li><a href="index.html#cvlocation" class="whitetext">CV</a></li>
-						<li><a href="index.html#contact" class="whitetext">Contact</a></li>
-					</ul>
-				</nav>
-			</header>
-			<div class="a">
-                                <section>
-                                        <h2>
-						About Me
-					</h2>
-					<p>Hello my name is Alexander and I a student studying Computer Science at Imperial College London</p>
-					<ul>
-						<li>Coding experience in Frontend and Backend Technologies, especially JavaScript and C#</li>
-						<li>Top A-Level Grades A*A*A*A with A*s in Maths, Further Maths and Computer Science</li>
-						<li>Computer Deal Hunting enthusiast and PC building extraordinaire</li>
-					</ul>
-				</section>
-        <section class="section-spacing">
-                <h2>
-                        Projects I've been working on:
-                </h2>
-                <div class="project-list">
-                        <a href="https://github.com/GAMINpanda/VSIM">
-                                <img class="project-img" src="images/Screenshot (223).png" alt="An interactive Virus Simulator"/>
-                        </a>
-                        <a href="https://github.com/GAMINpanda/New-Unity-Project">
-                                <img class="project-img" src="images/Screenshot (157).png" alt="Procedural Terrain System in Unity"/>
-                        </a>
-                        <a href="https://github.com/GAMINpanda/TimetablerSoftware">
-                                <img class="project-img" src="images/Screenshot (156).png" alt="A Timetabling Software"/>
-                        </a>
-                        <a href="https://github.com/GAMINpanda/LifeSimulation">
-                                <canvas id="sim" height="200" width="200"></canvas>
-                        </a>
-                </div>
-        </section>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Alexander Mitchiner | Home</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="StyleSheets.css" />
+</head>
+<body>
+<header class="site-header">
+    <div class="nav-wrap">
+        <h1 class="site-title">Alexander Mitchiner</h1>
+        <nav>
+            <ul class="nav-links">
+                <li><a class="active" href="index.html">Home</a></li>
+                <li><a href="articles.html">Articles</a></li>
+                <li><a href="art.html">Art</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+    </div>
+</header>
 
-        <section class="section-spacing" id="cvlocation">
-                <h2>
-						Curriculum Vitae
-					</h2>
-					<object data="cv.pdf" type="application/pdf" id="cv" width="1000" height="500">
-						<p>Your web browser doesn't have a PDF plugin.
-						Instead you can <a href="Profile.pdf">click here to
-						download the PDF file.</a></p>
-						</object>
-					<script src="cvresize.js"></script>
-				</section>
-                                <section class="section-spacing">
-                                        <h2>
-						Some examples of my art:
-					</h2>
-                                        <img class="art-img" src="images/tentacleman.png" alt="A man with tentacles for hair"/>
-                                        <img class="art-img" src="images/tearsinrainwithman.png" alt="A man standing in a courtyard with the night sky above him"/>
-                                        <img class="art-img" src="images/me_but_cute_and_young.png" alt="A digital painting of a younger self"/>
-				</section>
-				<section id="contact">
-					<hr>
-					<nav>
-						<ul>
-							<li>
-                                                                <a href="https://www.youtube.com/channel/UCqmTxpB8kqBPMWqyi9L9KOg"><img class="icon" src="images/youtubelogo.png"></a>
-							</li>
-							<li>
-                                                                <a href="https://github.com/GAMINpanda"><img class="icon" src="images/girhublogo.png"></a>
-							</li>
-							<li>
-                                                                <a href="https://www.instagram.com/gamin_panda/"><img class="icon" src="images/instalogo.png"></a>
-							</li>
-							<li>
-                                                                <a href="https://www.linkedin.com/in/alexander-mitchiner/"><img class="icon" src="images/linkedinlogo.png"></a>
-							</li>
-							<li>
-								<a href="https://substack.com/@alexandermitchiner"><img class="icon" src="images/substackfill.png"></a>
-							</li>
-						</ul>
-					</nav>
-				</section>
-			</div>
+<main class="page">
+    <section class="hero">
+        <div class="portrait-placeholder">
+            Self portrait<br />
+            (replace with your image)
+        </div>
+        <div>
+            <h2>Hi, I’m Alexander.</h2>
+            <p class="muted">Add your personal introduction here.</p>
+            <p>
+                This refreshed site is now split into separate pages for easier browsing: Home, Articles, Art, and
+                Contact.
+            </p>
+        </div>
+    </section>
 
-                        <script src="resize.js"></script>
-                        <script type="module" src="logic.js"></script>
-                        <script src="ui.js"></script>
-                </body>
-        </html>
+    <section class="grid">
+        <article class="card">
+            <h3>What I do</h3>
+            <p class="muted">
+                Use this card to describe your work and interests.
+            </p>
+        </article>
+        <article class="card">
+            <h3>Recent writing</h3>
+            <p class="muted">
+                Your newest Substack posts are pulled automatically on the Articles page.
+            </p>
+            <a href="articles.html">Go to Articles →</a>
+        </article>
+    </section>
+</main>
+</body>
+</html>

--- a/substack.js
+++ b/substack.js
@@ -1,0 +1,50 @@
+const SUBSTACK_FEED_URL = 'https://alexandermitchiner.substack.com/feed';
+const FALLBACK_SUBSTACK_PAGE = 'https://substack.com/@alexandermitchiner';
+
+async function loadSubstackPosts() {
+    const status = document.getElementById('article-status');
+    const list = document.getElementById('article-list');
+
+    try {
+        const proxyUrl = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(SUBSTACK_FEED_URL)}`;
+        const response = await fetch(proxyUrl);
+
+        if (!response.ok) {
+            throw new Error(`Could not fetch feed (status ${response.status}).`);
+        }
+
+        const data = await response.json();
+        const posts = (data.items || []).slice(0, 6);
+
+        if (posts.length === 0) {
+            throw new Error('No posts found in feed.');
+        }
+
+        list.innerHTML = posts
+            .map((post) => {
+                const date = new Date(post.pubDate);
+                const dateLabel = Number.isNaN(date.getTime())
+                    ? 'Date unavailable'
+                    : date.toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric'
+                    });
+
+                return `
+                    <li>
+                        <h3><a href="${post.link}" target="_blank" rel="noopener noreferrer">${post.title}</a></h3>
+                        <time datetime="${post.pubDate}">${dateLabel}</time>
+                    </li>
+                `;
+            })
+            .join('');
+
+        status.textContent = 'Latest posts loaded automatically from Substack.';
+    } catch (error) {
+        console.error(error);
+        status.innerHTML = `Couldn't load posts automatically right now. <a href="${FALLBACK_SUBSTACK_PAGE}" target="_blank" rel="noopener noreferrer">Visit Substack directly</a>.`;
+    }
+}
+
+loadSubstackPosts();


### PR DESCRIPTION
### Motivation
- Refresh the site's look and layout to a cleaner, more modern responsive design. 
- Replace the single long-scroll homepage with separate pages for clearer navigation and discovery. 
- Surface recent writing by automatically showing recent Substack posts instead of the old projects list. 
- Provide a dedicated spot for a self-portrait and personal intro while removing the CV section as requested.

### Description
- Split the site into distinct pages and navigation by adding `index.html`, `articles.html`, `art.html`, and `contact.html` and updating links accordingly. 
- Reworked global styles with a new `StyleSheets.css` to provide a card-based, responsive layout and improved spacing and visuals. 
- Added `substack.js` which fetches the Substack RSS via an RSS→JSON proxy and populates the `articles.html` list with the latest posts with a graceful fallback link. 
- Removed the CV/projects sections from the homepage and added a `portrait-placeholder` area for a self portrait and short intro text.

### Testing
- Ran a static check of the Substack script with `node --check substack.js`, which completed successfully. 
- Verified repository state with `git status --short` and committed the changes, producing the new files and updated `StyleSheets.css` (commit completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8a647de08832aa17be5d8bf0b507c)